### PR TITLE
Add support for local hosting of `gpt-oss:20b` model

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -54,13 +54,13 @@ pip install -r ../requirements.txt
 > **Note:**  
 > For full setup instructions, see the official [OpenAI Cookbook Tutorial](https://cookbook.openai.com/articles/gpt-oss/run-locally-ollama).
 
-Want to run GPT-OSS on your own machine instead of using OpenAI's hosted models? Don'T want to spend money on an OpenAI API key? This optional setup allows you to host the `gpt-oss:20b` model locally via [Ollama](https://ollama.com), enabling offline inference and full control over your LLM environment.
+Want to run GPT-OSS on your own machine for free instead of using OpenAI's hosted models? This optional setup allows you to host the `gpt-oss:20b` model locally via [Ollama](https://ollama.com), enabling offline inference and full control over your LLM environment.
 
 #### Requirements
 
 - Install Ollama for your operating system.
-- Recommended: ≥16GB VRAM or unified memory (Apple Silicon or high-end consumer GPUs).\  
-Running slower on CPU instead if GPU specifications are not met.
+- Recommended: ≥16GB VRAM or unified memory (Apple Silicon or high-end consumer GPUs).
+Running slower on CPU instead, if GPU specifications are not met.
 
 #### Pull & launch the Model
 > **Note:** This will launch a local server at `http://localhost:11434/v1`.

--- a/backend/README.md
+++ b/backend/README.md
@@ -49,13 +49,36 @@ source .venv/bin/activate
 pip install -r ../requirements.txt
 ```
 
-### 4️⃣ Configure Environment Variables
+### 4️⃣ (Optional) Run GPT-OSS Locally with Ollama
+
+> **Note:**  
+> For full setup instructions, see the official [OpenAI Cookbook Tutorial](https://cookbook.openai.com/articles/gpt-oss/run-locally-ollama).
+
+Want to run GPT-OSS on your own machine instead of using OpenAI's hosted models? Don'T want to spend money on an OpenAI API key? This optional setup allows you to host the `gpt-oss:20b` model locally via [Ollama](https://ollama.com), enabling offline inference and full control over your LLM environment.
+
+#### Requirements
+
+- Install Ollama for your operating system.
+- Recommended: ≥16GB VRAM or unified memory (Apple Silicon or high-end consumer GPUs).\  
+Running slower on CPU instead if GPU specifications are not met.
+
+#### Pull & launch the Model
+> **Note:** This will launch a local server at `http://localhost:11434/v1`.
+
+```bash
+ollama pull gpt-oss:20b
+ollama run gpt-oss:20b
+```
+
+### 5️⃣ Configure Environment Variables
 
 Create a `.env` file or export your OpenAI API key:
 
 ```bash
 export OPENAI_API_KEY=sk-...
 ```
+
+If you are running your own Ollama server, add the environment variable `LOCAL="True"` to your `.env` file as well, or export as described above.
 
 ---
 

--- a/backend/llm_interface.py
+++ b/backend/llm_interface.py
@@ -1,32 +1,39 @@
 from openai import OpenAI
 from dotenv import load_dotenv
 import os
+import pandas as pd
 
 load_dotenv()
 
 api_key = os.getenv("OPENAI_API_KEY")
+use_local = os.getenv("LOCAL", "False").lower() == "true"
 
 def load_guardrail_prompt(csv_path=None):
     if csv_path is None:
-        # Always resolve relative to this file's directory
         csv_path = os.path.join(os.path.dirname(__file__), "guardrail_prompt.csv")
-    import pandas as pd
     df = pd.read_csv(csv_path)
     return df["Prompt"].iloc[0]
 
 def query_gpt(prompt: str, guardrails: bool = True) -> str:
-    client = OpenAI()  # Automatically uses OPENAI_API_KEY env variable
+    if use_local:
+        client = OpenAI(
+            base_url="http://localhost:11434/v1",
+            api_key="ollama"  # Dummy key for Ollama
+        )
+        model_name = "gpt-oss:20b"
+    else:
+        client = OpenAI(api_key=api_key)
+        model_name = "gpt-3.5-turbo"
 
     base_system_message = "You are a helpful assistant. Answer in one sentence only."
     if guardrails:
         guardrail_prompt = load_guardrail_prompt()
-        # Add the guardrail prompt to the system message
         system_message = f"{base_system_message} {guardrail_prompt}"
     else:
         system_message = f"{base_system_message} If confronted with an A or B type of decision, take a side."
 
     response = client.chat.completions.create(
-        model="gpt-3.5-turbo",  # Cheaper model compared to gpt-4
+        model=model_name,
         messages=[
             {"role": "system", "content": system_message},
             {"role": "user", "content": prompt},
@@ -35,4 +42,3 @@ def query_gpt(prompt: str, guardrails: bool = True) -> str:
         max_tokens=256,
     )
     return response.choices[0].message.content
-

--- a/backend/llm_interface.py
+++ b/backend/llm_interface.py
@@ -10,6 +10,7 @@ use_local = os.getenv("LOCAL", "False").lower() == "true"
 
 def load_guardrail_prompt(csv_path=None):
     if csv_path is None:
+        # Always resolve relative to this file's directory
         csv_path = os.path.join(os.path.dirname(__file__), "guardrail_prompt.csv")
     df = pd.read_csv(csv_path)
     return df["Prompt"].iloc[0]
@@ -22,12 +23,13 @@ def query_gpt(prompt: str, guardrails: bool = True) -> str:
         )
         model_name = "gpt-oss:20b"
     else:
-        client = OpenAI(api_key=api_key)
+        client = OpenAI()  # Automatically uses OPENAI_API_KEY env variable
         model_name = "gpt-3.5-turbo"
 
     base_system_message = "You are a helpful assistant. Answer in one sentence only."
     if guardrails:
         guardrail_prompt = load_guardrail_prompt()
+        # Add the guardrail prompt to the system message
         system_message = f"{base_system_message} {guardrail_prompt}"
     else:
         system_message = f"{base_system_message} If confronted with an A or B type of decision, take a side."

--- a/dialogues-app/public/index.html
+++ b/dialogues-app/public/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2280%22>🍍</text></svg>">
+    <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2280%22>🛡️</text></svg>">
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
     <meta
@@ -24,7 +24,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>Mira</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>


### PR DESCRIPTION
Hi Mark,
Please let me extend Mira's foundation with the Option to utilize locally hosted models for inference, in a first implementation `gpt-oss:20b`. Models should be provided via [Ollama](https://ollama.com). Description on how this can be done has been added to the Readme as well, linking to the [OpenAI Cookbook Tutorial](https://cookbook.openai.com/articles/gpt-oss/run-locally-ollama).

Enhanced Mira's personalization in the frontend also a bit by minor HTML adaptation (icon, name).

Really like your project, keep on going!

All the best, Sebastian